### PR TITLE
#25 Add try/catch around module reading to prevent crashes when assemblies are native ones (.net native) and there is no interceptor implemented

### DIFF
--- a/Fody/InterceptorFinder.cs
+++ b/Fody/InterceptorFinder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Mono.Cecil;
 
@@ -31,17 +32,27 @@ public partial class ModuleWeaver
                 continue;
             }
 
+            var stopwatch = Stopwatch.StartNew();
+
             ModuleDefinition moduleDefinition;
 
             try
             {
+                LogDebug(string.Format("Reading module from '{0}'", referencePath));
+
                 moduleDefinition = ReadModule(referencePath);
             }
             catch (Exception)
             {
-                LogDebug(string.Format("Failed to read module from '{0}', probably a .net native assembly", referencePath));
+                stopwatch.Stop();
+
+                LogDebug(string.Format("Failed to read module, probably a .net native assembly, took {0} ms", stopwatch.ElapsedMilliseconds));
                 continue;
             }
+
+            stopwatch.Stop();
+
+            //LogDebug(string.Format("Read module, took {0} ms", stopwatch.ElapsedMilliseconds));
 
             interceptor = moduleDefinition
                 .GetTypes()

--- a/Fody/InterceptorFinder.cs
+++ b/Fody/InterceptorFinder.cs
@@ -8,6 +8,8 @@ public partial class ModuleWeaver
 
     public void FindInterceptor()
     {
+        LogDebug(string.Format("Searching for an intercepter"));
+
         var interceptor = types.FirstOrDefault(x => x.IsInterceptor());
         if (interceptor != null)
         {
@@ -21,13 +23,25 @@ public partial class ModuleWeaver
             LogMethod = logMethod;
             return;
         }
+
         foreach (var referencePath in ReferenceCopyLocalPaths)
         {
             if (!referencePath.EndsWith(".dll") && !referencePath.EndsWith(".exe"))
             {
                 continue;
             }
-            var moduleDefinition = ReadModule(referencePath);
+
+            ModuleDefinition moduleDefinition;
+
+            try
+            {
+                moduleDefinition = ReadModule(referencePath);
+            }
+            catch (Exception)
+            {
+                LogDebug(string.Format("Failed to read module from '{0}', probably a .net native assembly", referencePath));
+                continue;
+            }
 
             interceptor = moduleDefinition
                 .GetTypes()

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -1,13 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 
 public partial class ModuleWeaver
 {
+    public Action<string> LogDebug { get; set; }
     public Action<string> LogInfo { get; set; }
-    public Action<string> LogError { get; set; }
     public Action<string> LogWarning { get; set; }
+    public Action<string, SequencePoint> LogWarningPoint { get; set; }
+    public Action<string> LogError { get; set; }
+    public Action<string, SequencePoint> LogErrorPoint { get; set; }
     public ModuleDefinition ModuleDefinition { get; set; }
     public IAssemblyResolver AssemblyResolver { get; set; }
     List<TypeDefinition> types;
@@ -15,8 +20,13 @@ public partial class ModuleWeaver
 
     public ModuleWeaver()
     {
-        LogInfo = s => { };
-        LogError = s => { };
+        LogDebug = s => { Debug.WriteLine(s); };
+        LogInfo = s => { Debug.WriteLine(s); };
+        LogWarning = s => { Debug.WriteLine(s); };
+        LogWarningPoint = (s, p) => { Debug.WriteLine(s); };
+        LogError = s => { Debug.WriteLine(s); };
+        LogErrorPoint = (s, p) => { Debug.WriteLine(s); };
+
         ReferenceCopyLocalPaths = new List<string>();
     }
 
@@ -30,5 +40,4 @@ public partial class ModuleWeaver
         RemoveAttributes();
         RemoveReference();
     }
-
 }


### PR DESCRIPTION
Fixes #25