### PR TITLE
Feature/async fixes

### DIFF
--- a/AssemblyWithInterceptorAndFormatting/ClassWithAsyncMethod.cs
+++ b/AssemblyWithInterceptorAndFormatting/ClassWithAsyncMethod.cs
@@ -8,11 +8,21 @@ public class ClassWithAsyncMethod
     [Time("File name '{fileName}' with id '{id}'")]
     public async Task MethodWithAwaitAsync(string fileName, int id)
     {
+        await Task.Delay(500);
+
         // Use so the compiler won't optimize
         Console.Write(fileName);
         Console.Write(id);
+    }
 
+    [Time]
+    public async Task MethodWithAwaitWithoutFormattingAsync(string fileName, int id)
+    {
         await Task.Delay(500);
+
+        // Use so the compiler won't optimize
+        Console.Write(fileName);
+        Console.Write(id);
     }
 
     [Time("File name '{fileName}' with id '{id}'")]

--- a/AssemblyWithInterceptorAndFormattingWithoutOverload/MethodTimeLogger.cs
+++ b/AssemblyWithInterceptorAndFormattingWithoutOverload/MethodTimeLogger.cs
@@ -9,8 +9,13 @@ public static class MethodTimeLogger
 
     public static void Log(MethodBase methodBase, long milliseconds)
     {
-        Console.WriteLine(methodBase.Name + " " + milliseconds);
+        Log(methodBase.DeclaringType, methodBase.Name, milliseconds);
         MethodBase.Add(methodBase);
+    }
+
+    public static void Log(Type type, string methodName, long milliseconds)
+    {
+        Console.WriteLine(methodName + " " + milliseconds);
     }
 
 }

--- a/Fody/AsyncMethodProcessor.cs
+++ b/Fody/AsyncMethodProcessor.cs
@@ -14,7 +14,7 @@ public class AsyncMethodProcessor
     FieldDefinition stopwatchField;
     TypeDefinition stateMachineType;
     List<Instruction> returnPoints;
-    ParameterFormattingProcessor parameterFormattingProcessor = new ParameterFormattingProcessor();
+    readonly ParameterFormattingProcessor parameterFormattingProcessor = new ParameterFormattingProcessor();
 
     public void Process()
     {
@@ -283,6 +283,7 @@ public class AsyncMethodProcessor
                 else
                 {
                     // Load null a string
+                    yield return Instruction.Create(OpCodes.Ldarg_0);
                     yield return Instruction.Create(OpCodes.Ldnull);
                 }
 

--- a/Fody/InterceptorFinder.cs
+++ b/Fody/InterceptorFinder.cs
@@ -84,13 +84,18 @@ public partial class ModuleWeaver
 
     MethodDefinition FindLogMethod(TypeDefinition interceptorType)
     {
-        var logMethod = interceptorType.Methods.FirstOrDefault(x => x.Name == "Log" && x.Parameters.Count == 2);
+        var requiredParameterTypes = new[] { "System.Reflection.MethodBase", "System.Int64" };
+
+        var logMethod = interceptorType.Methods.FirstOrDefault(x => x.Name == "Log" &&
+                                                               x.Parameters.Count == 2 &&
+                                                               x.Parameters[0].ParameterType.FullName == requiredParameterTypes[0] &&
+                                                               x.Parameters[1].ParameterType.FullName == requiredParameterTypes[1]);
         if (logMethod == null)
         {
             return null;
         }
 
-        VerifyHasCorrectParameters(logMethod, new [] { "System.Reflection.MethodBase", "System.Int64" });
+        VerifyHasCorrectParameters(logMethod, requiredParameterTypes);
         VerifyMethodIsPublicStatic(logMethod);
         LogMethod = ModuleDefinition.ImportReference(logMethod);
         CheckNop(logMethod);
@@ -100,13 +105,19 @@ public partial class ModuleWeaver
 
     MethodDefinition FindLogWithMessageMethod(TypeDefinition interceptorType)
     {
-        var logMethod = interceptorType.Methods.FirstOrDefault(x => x.Name == "Log" && x.Parameters.Count == 3);
+        var requiredParameterTypes = new[] { "System.Reflection.MethodBase", "System.Int64", "System.String" };
+
+        var logMethod = interceptorType.Methods.FirstOrDefault(x => x.Name == "Log" &&
+                                                                    x.Parameters.Count == 3 &&
+                                                                    x.Parameters[0].ParameterType.FullName == requiredParameterTypes[0] &&
+                                                                    x.Parameters[1].ParameterType.FullName == requiredParameterTypes[1] &&
+                                                                    x.Parameters[2].ParameterType.FullName == requiredParameterTypes[2]);
         if (logMethod == null)
         {
             return null;
         }
 
-        VerifyHasCorrectParameters(logMethod, new[] { "System.Reflection.MethodBase", "System.Int64", "System.String" });
+        VerifyHasCorrectParameters(logMethod, requiredParameterTypes);
         VerifyMethodIsPublicStatic(logMethod);
         LogMethod = ModuleDefinition.ImportReference(logMethod);
         CheckNop(logMethod);

--- a/Tests/AssemblyTestersests/WithInterceptorAndFormattingTests.cs
+++ b/Tests/AssemblyTestersests/WithInterceptorAndFormattingTests.cs
@@ -95,6 +95,32 @@ public class WithInterceptorAndFormattingTests
 
     [RequiresSTA]
     [Test]
+    public void ClassWithAsyncWithoutFormattingMethod()
+    {
+        ClearMessage();
+
+        var type = assemblyWeaver.Assembly.GetType("ClassWithAsyncMethod");
+        var instance = (dynamic)Activator.CreateInstance(type);
+        DebugRunner.CaptureDebug(() =>
+        {
+            var task = (Task)instance.MethodWithAwaitWithoutFormattingAsync("123", 42);
+            task.Wait();
+        });
+
+        var methodBases = GetMethodInfoField();
+        Assert.AreEqual(1, methodBases.Count);
+
+        var methodBase = methodBases.First();
+        Assert.AreEqual(methodBase.Name, "MethodWithAwaitWithoutFormattingAsync");
+
+        var messages = GetMessagesField();
+        Assert.AreEqual(0, messages.Count);
+    }
+
+    // Note: in DEBUG because this only needs to run against optimized libraries
+#if !DEBUG
+    [RequiresSTA]
+    [Test]
     public void ClassWithAsyncMethodWithUnusedParameters()
     {
         ClearMessage();
@@ -112,6 +138,7 @@ public class WithInterceptorAndFormattingTests
         var error = assemblyWeaver.Errors.First();
         Assert.AreEqual("Parameter 'fileName' is not available on the async state machine. Probably it has been optimized away by the compiler. Please update the format so it excludes this parameter.", error);
     }
+#endif
 
     [RequiresSTA]
     [Test]


### PR DESCRIPTION
2 fixes:

1. Async methods without format in an assembly with an interceptor with the format overload caused invalid IL
2. Improved the interceptor checking mechanism. This to prevent selecting the wrong overload based only on parameter count (resulting in an error).