### PR TITLE
Add support for '{this}' in the message format

### DIFF
--- a/AssemblyWithInterceptorAndFormatting/ClassWithAsyncMethod.cs
+++ b/AssemblyWithInterceptorAndFormatting/ClassWithAsyncMethod.cs
@@ -15,6 +15,16 @@ public class ClassWithAsyncMethod
         Console.Write(id);
     }
 
+    [Time("Current object: '{this}' | File name '{fileName}' with id '{id}'")]
+    public async Task MethodWithAwaitAndThisAsync(string fileName, int id)
+    {
+        await Task.Delay(500);
+
+        // Use so the compiler won't optimize
+        Console.Write(fileName);
+        Console.Write(id);
+    }
+
     [Time]
     public async Task MethodWithAwaitWithoutFormattingAsync(string fileName, int id)
     {
@@ -70,5 +80,10 @@ public class ClassWithAsyncMethod
         }
 
         isRunning = false;
+    }
+
+    public override string ToString()
+    {
+        return $"TEST VALUE";
     }
 }

--- a/AssemblyWithInterceptorAndFormatting/ClassWithMethod.cs
+++ b/AssemblyWithInterceptorAndFormatting/ClassWithMethod.cs
@@ -16,6 +16,12 @@ public class ClassWithMethod
         Thread.Sleep(10);
     }
 
+    [Time("Current object: '{this}' | File name '{fileName}' with id '{id}'")]
+    public void MethodWithThis(string fileName, int id)
+    {
+        Thread.Sleep(10);
+    }
+
     public void Method_Expected(string fileName, int id)
     {
         var stopwatch = Stopwatch.StartNew();
@@ -29,5 +35,10 @@ public class ClassWithMethod
             var methodTimerMessage = string.Format("File name '{0}' with id '{1}'", new object [] { fileName, id });
             MethodTimeLogger.Log(null, stopwatch.ElapsedMilliseconds, methodTimerMessage);
         }
+    }
+
+    public override string ToString()
+    {
+        return $"TEST VALUE";
     }
 }

--- a/AssemblyWithInterceptorAndFormatting/ClassWithMethod.cs
+++ b/AssemblyWithInterceptorAndFormatting/ClassWithMethod.cs
@@ -16,12 +16,6 @@ public class ClassWithMethod
         Thread.Sleep(10);
     }
 
-    [Time("Current object: '{this}' | File name '{fileName}' with id '{id}'")]
-    public void MethodWithThis(string fileName, int id)
-    {
-        Thread.Sleep(10);
-    }
-
     public void Method_Expected(string fileName, int id)
     {
         var stopwatch = Stopwatch.StartNew();
@@ -32,7 +26,28 @@ public class ClassWithMethod
         finally
         {
             stopwatch.Stop();
-            var methodTimerMessage = string.Format("File name '{0}' with id '{1}'", new object [] { fileName, id });
+            var methodTimerMessage = string.Format("File name '{0}' with id '{1}'", new object[] { fileName, id });
+            MethodTimeLogger.Log(null, stopwatch.ElapsedMilliseconds, methodTimerMessage);
+        }
+    }
+
+    [Time("Current object: '{this}' | File name '{fileName}' with id '{id}'")]
+    public void MethodWithThis(string fileName, int id)
+    {
+        Thread.Sleep(10);
+    }
+
+    public void MethodWithThis_Expected(string fileName, int id)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            Thread.Sleep(10);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            var methodTimerMessage = string.Format("Current object: '{0}' | File name '{1}' with id '{2}'", new object[] { this, fileName, id });
             MethodTimeLogger.Log(null, stopwatch.ElapsedMilliseconds, methodTimerMessage);
         }
     }

--- a/AssemblyWithInterceptorAndFormattingWithThisInStaticMember/AssemblyWithInterceptorAndFormattingWithThisInStaticMember.csproj
+++ b/AssemblyWithInterceptorAndFormattingWithThisInStaticMember/AssemblyWithInterceptorAndFormattingWithThisInStaticMember.csproj
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MethodTimer\MethodTimer.csproj" />
+  </ItemGroup>
+</Project>

--- a/AssemblyWithInterceptorAndFormattingWithThisInStaticMember/ClassWithMethod.cs
+++ b/AssemblyWithInterceptorAndFormattingWithThisInStaticMember/ClassWithMethod.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading;
+using MethodTimer;
+
+public static class ClassWithMethod
+{
+    [Time("File name: '{this}' with id '{id}'")]
+    public static void Method(string fileName, int id)
+    {
+        Thread.Sleep(10);
+    }
+}

--- a/AssemblyWithInterceptorAndFormattingWithThisInStaticMember/MethodTimeLogger.cs
+++ b/AssemblyWithInterceptorAndFormattingWithThisInStaticMember/MethodTimeLogger.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+public static class MethodTimeLogger
+{
+
+    public static List<MethodBase> MethodBase = new List<MethodBase>();
+    public static List<string> Messages = new List<string>();
+
+    public static void Log(MethodBase methodBase, long milliseconds, string message)
+    {
+        Console.WriteLine(methodBase.Name + " " + milliseconds + ": " + message);
+
+        MethodBase.Add(methodBase);
+
+        if (message != null)
+        {
+            Messages.Add(message);
+        }
+    }
+
+}

--- a/AssemblyWithTimeSpanInterceptorAndFormatting/ClassWithAsyncMethod.cs
+++ b/AssemblyWithTimeSpanInterceptorAndFormatting/ClassWithAsyncMethod.cs
@@ -15,6 +15,16 @@ public class ClassWithAsyncMethod
         Console.Write(id);
     }
 
+    [Time("Current object: '{this}' | File name '{fileName}' with id '{id}'")]
+    public async Task MethodWithAwaitAndThisAsync(string fileName, int id)
+    {
+        await Task.Delay(500);
+
+        // Use so the compiler won't optimize
+        Console.Write(fileName);
+        Console.Write(id);
+    }
+
     [Time]
     public async Task MethodWithAwaitWithoutFormattingAsync(string fileName, int id)
     {
@@ -70,5 +80,10 @@ public class ClassWithAsyncMethod
         }
 
         isRunning = false;
+    }
+
+    public override string ToString()
+    {
+        return $"TEST VALUE";
     }
 }

--- a/AssemblyWithTimeSpanInterceptorAndFormatting/ClassWithMethod.cs
+++ b/AssemblyWithTimeSpanInterceptorAndFormatting/ClassWithMethod.cs
@@ -26,8 +26,34 @@ public class ClassWithMethod
         finally
         {
             stopwatch.Stop();
-            var methodTimerMessage = string.Format("File name '{0}' with id '{1}'", new object [] { fileName, id });
+            var methodTimerMessage = string.Format("File name '{0}' with id '{1}'", new object[] { fileName, id });
             MethodTimeLogger.Log(null, stopwatch.ElapsedMilliseconds, methodTimerMessage);
         }
+    }
+
+    [Time("Current object: '{this}' | File name '{fileName}' with id '{id}'")]
+    public void MethodWithThis(string fileName, int id)
+    {
+        Thread.Sleep(10);
+    }
+
+    public void MethodWithThis_Expected(string fileName, int id)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            Thread.Sleep(10);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            var methodTimerMessage = string.Format("Current object: '{0}' | File name '{1}' with id '{2}'", new object[] { this, fileName, id });
+            MethodTimeLogger.Log(null, stopwatch.ElapsedMilliseconds, methodTimerMessage);
+        }
+    }
+
+    public override string ToString()
+    {
+        return $"TEST VALUE";
     }
 }

--- a/MethodTimer.Fody/AssemblyProcessor.cs
+++ b/MethodTimer.Fody/AssemblyProcessor.cs
@@ -92,11 +92,22 @@ public partial class ModuleWeaver
                 for (var i = 0; i < info.ParameterNames.Count; i++)
                 {
                     var parameterName = info.ParameterNames[i];
-                    var containsParameter = method.Parameters.Any(x => x.Name.Equals(parameterName));
-                    if (!containsParameter)
+                    if (string.Equals(parameterName, "this"))
                     {
-                        hasErrors = true;
-                        LogError(string.Format("Could not process '" + method.FullName + "' because the format uses '{0}' which is not available as method parameter.", parameterName));
+                        if (method.IsStatic)
+                        {
+                            hasErrors = true;
+                            LogError($"Could not process '{method.FullName}' because the format uses 'this' in a static context.");
+                        }
+                    }
+                    else
+                    {
+                        var containsParameter = method.Parameters.Any(x => x.Name.Equals(parameterName));
+                        if (!containsParameter)
+                        {
+                            hasErrors = true;
+                            LogError($"Could not process '{method.FullName}' because the format uses '{parameterName}' which is not available as method parameter.");
+                        }
                     }
                 }
 

--- a/MethodTimer.Fody/AsyncMethodProcessor.cs
+++ b/MethodTimer.Fody/AsyncMethodProcessor.cs
@@ -321,6 +321,11 @@ public class AsyncMethodProcessor
                     {
                         // Field name is <>4__this
                         parameterName = "<>4__this";
+                        if (!stateMachineType.Fields.Any(x => x.Name.Equals(parameterName)))
+                        {
+                            // {this} could be optimized away, let's add it for the user
+                            InjectThisIntoStateMachine(methodDefinition, stateMachineType);
+                        }
                     }
 
                     var field = stateMachineType.Fields.FirstOrDefault(x => x.Name.Equals(parameterName));
@@ -354,5 +359,47 @@ public class AsyncMethodProcessor
 
             yield return Instruction.Create(OpCodes.Stfld, formattedFieldDefinition);
         }
+    }
+
+    void InjectThisIntoStateMachine(MethodDefinition methodDefinition, TypeDefinition stateMachineType)
+    {
+        // Step 1: inject the field
+        var thisField = new FieldDefinition("<>4__this", FieldAttributes.Public, methodDefinition.DeclaringType);
+        stateMachineType.Fields.Add(thisField);
+
+        // Step 2: set the field value in the actual method, search for the first usage of the state machine class
+        var methodBody = methodDefinition.Body;
+        methodBody.SimplifyMacros();
+
+        var instructions = methodDefinition.Body.Instructions;
+        var startInstruction = instructions.FirstOrDefault(x =>
+        {
+            if (x.Operand is VariableDefinition variableDefinition)
+            {
+                if (variableDefinition.VariableType.FullName.Equals(stateMachineType.FullName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        if (startInstruction is null)
+        {
+            ModuleWeaver.LogError($"Failed to inject '{{this}}' into the async method, the compiler optimized it away and it could not be injected automatically, please create a support ticket.");
+            return;
+        }
+
+        // IL_0000: ldloca.s     'stateMachine [Range(Instruction(IL_0000 ldloca.s)-Instruction(IL_003c ldloca.s))]'
+        // IL_0002: ldarg.0      // this
+        // IL_0003: stfld        class ClassWithAsyncMethod ClassWithAsyncMethod/'<MethodWithAwaitAndThisAsync>d__1'::'<>4__this'
+
+        var index = instructions.IndexOf(startInstruction);
+        instructions.Insert(index + 0, Instruction.Create(OpCodes.Ldloca_S, (VariableDefinition)startInstruction.Operand));
+        instructions.Insert(index + 1, Instruction.Create(OpCodes.Ldarg_0));
+        instructions.Insert(index + 2, Instruction.Create(OpCodes.Stfld, thisField));
+
+        methodBody.OptimizeMacros();
     }
 }

--- a/MethodTimer.sln
+++ b/MethodTimer.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithTimeSpanInterceptorAndFormatting", "AssemblyWithTimeSpanInterceptorAndFormatting\AssemblyWithTimeSpanInterceptorAndFormatting.csproj", "{738F52D9-7ACA-4BCC-907E-5771D9A9B351}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithInterceptorAndFormattingWithThisInStaticMember", "AssemblyWithInterceptorAndFormattingWithThisInStaticMember\AssemblyWithInterceptorAndFormattingWithThisInStaticMember.csproj", "{12DDBBCA-230F-40A5-BF41-1B79732993DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -138,6 +140,14 @@ Global
 		{738F52D9-7ACA-4BCC-907E-5771D9A9B351}.Release|Any CPU.Build.0 = Release|Any CPU
 		{738F52D9-7ACA-4BCC-907E-5771D9A9B351}.Release|x86.ActiveCfg = Release|Any CPU
 		{738F52D9-7ACA-4BCC-907E-5771D9A9B351}.Release|x86.Build.0 = Release|Any CPU
+		{12DDBBCA-230F-40A5-BF41-1B79732993DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12DDBBCA-230F-40A5-BF41-1B79732993DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12DDBBCA-230F-40A5-BF41-1B79732993DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12DDBBCA-230F-40A5-BF41-1B79732993DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{12DDBBCA-230F-40A5-BF41-1B79732993DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12DDBBCA-230F-40A5-BF41-1B79732993DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12DDBBCA-230F-40A5-BF41-1B79732993DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{12DDBBCA-230F-40A5-BF41-1B79732993DC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -196,7 +196,14 @@ public class MyClass
 }
 ```
 
-**Note that this feature requires an updated Log method call with the definition below. If this method (with the *message* parameter) is not found, the weaver will raise an error.**
+The following values are allowed:
+
+* Any parameter name (e.g. `{fileName}`)
+* `{this}` (calls `ToString()` on the instance itself) - Note that this is not available on static methods, the weaver will throw an error if being used in a static method
+
+**Note 1:** sub-properties are not (yet?) supported. [Support Fody on OpenCollective](https://opencollective.com/fody) and this might be implemented!
+
+**Note 2:** this feature requires an updated Log method call with the definition below. If this method (with the *message* parameter) is not found, the weaver will raise an error.
 
 ```
 public static void Log(MethodBase methodBase, long milliseconds, string message)

--- a/Tests/AssemblyTesterSets/AssemblyWithInterceptorAndFormattingWithThisInStaticMemberTests.cs
+++ b/Tests/AssemblyTesterSets/AssemblyWithInterceptorAndFormattingWithThisInStaticMemberTests.cs
@@ -1,0 +1,14 @@
+﻿using System.Linq;
+using Fody;
+using Xunit;
+
+public class AssemblyWithInterceptorAndFormattingWithThisInStaticMemberTests
+{
+    [Fact]
+    public void RaisesErrorForThisInStaticMember()
+    {
+        var weavingTask = new ModuleWeaver();
+        var testResult = weavingTask.ExecuteTestRun("AssemblyWithInterceptorAndFormattingWithWrongParameters.dll");
+        Assert.Equal("Could not process 'System.Void ClassWithMethod::Method(System.String,System.Int32)' because the format uses 'this' in a static context.", testResult.Errors.Single().Text);
+    }
+}

--- a/Tests/AssemblyTesterSets/AssemblyWithInterceptorAndFormattingWithThisInStaticMemberTests.cs
+++ b/Tests/AssemblyTesterSets/AssemblyWithInterceptorAndFormattingWithThisInStaticMemberTests.cs
@@ -8,7 +8,7 @@ public class AssemblyWithInterceptorAndFormattingWithThisInStaticMemberTests
     public void RaisesErrorForThisInStaticMember()
     {
         var weavingTask = new ModuleWeaver();
-        var testResult = weavingTask.ExecuteTestRun("AssemblyWithInterceptorAndFormattingWithWrongParameters.dll");
+        var testResult = weavingTask.ExecuteTestRun("AssemblyWithInterceptorAndFormattingWithThisInStaticMember.dll");
         Assert.Equal("Could not process 'System.Void ClassWithMethod::Method(System.String,System.Int32)' because the format uses 'this' in a static context.", testResult.Errors.Single().Text);
     }
 }

--- a/Tests/AssemblyTesterSets/IgnoreCodes.cs
+++ b/Tests/AssemblyTesterSets/IgnoreCodes.cs
@@ -4,10 +4,10 @@ public static class IgnoreCodes
 {
     public static IEnumerable<string> GetIgnoreCoders()
     {
-#if NET471
+#if NET472
         return System.Linq.Enumerable.Empty<string>();
 #endif
-#if NETCOREAPP2_1
+#if NETCOREAPP2_2
         return new[] { "0x80131869" };
 #endif
     }

--- a/Tests/AssemblyTesterSets/WithTimeSpanInterceptorAndFormattingTests.cs
+++ b/Tests/AssemblyTesterSets/WithTimeSpanInterceptorAndFormattingTests.cs
@@ -68,7 +68,7 @@ public class WithTimeSpanInterceptorAndFormattingTests
 
         var type = testResult.Assembly.GetType("ClassWithMethod");
         var instance = (dynamic)Activator.CreateInstance(type);
-        instance.Method("123", 42);
+        instance.MethodWithThis("123", 42);
 
         var methodBases = GetMethodInfoField();
         Assert.Single(methodBases);
@@ -81,7 +81,7 @@ public class WithTimeSpanInterceptorAndFormattingTests
         Assert.Single(messages);
 
         var message = messages.First();
-        Assert.Equal("Current object: '{TEST VALUE}' | File name '123' with id '42'", message);
+        Assert.Equal("Current object: 'TEST VALUE' | File name '123' with id '42'", message);
 
         // Note: must prefer TimeSpan above long
         var interceptorTypes = GetInterceptorTypesField();
@@ -160,7 +160,7 @@ public class WithTimeSpanInterceptorAndFormattingTests
         var instance = (dynamic)Activator.CreateInstance(type);
         TraceRunner.Capture(() =>
         {
-            var task = (Task)instance.MethodWithAwaitAsync("123", 42);
+            var task = (Task)instance.MethodWithAwaitAndThisAsync("123", 42);
             task.Wait();
         });
 
@@ -174,7 +174,7 @@ public class WithTimeSpanInterceptorAndFormattingTests
         Assert.Single(messages);
 
         var message = messages.First();
-        Assert.Equal("Current object: '{TEST VALUE}' | File name '123' with id '42'", message);
+        Assert.Equal("Current object: 'TEST VALUE' | File name '123' with id '42'", message);
 
         // Note: must prefer TimeSpan above long
         var interceptorTypes = GetInterceptorTypesField();

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\AssemblyWithAttributeOnAssembly\AssemblyWithAttributeOnAssembly.csproj" />
     <ProjectReference Include="..\AssemblyWithAttributeOnModule\AssemblyWithAttributeOnModule.csproj" />
     <ProjectReference Include="..\AssemblyWithInterceptorAndFormattingWithoutOverload\AssemblyWithInterceptorAndFormattingWithoutOverload.csproj" />
+    <ProjectReference Include="..\AssemblyWithInterceptorAndFormattingWithThisInStaticMember\AssemblyWithInterceptorAndFormattingWithThisInStaticMember.csproj" />
     <ProjectReference Include="..\AssemblyWithInterceptorAndFormattingWithWrongParameters\AssemblyWithInterceptorAndFormattingWithWrongParameters.csproj" />
     <ProjectReference Include="..\AssemblyWithInterceptorAndFormatting\AssemblyWithInterceptorAndFormatting.csproj" />
     <ProjectReference Include="..\AssemblyWIthInterceptorInReference\AssemblyWithInterceptorInReference.csproj" />


### PR DESCRIPTION
1. Added docs
3. Add the following features (and covered with tests):

a. Throw error in case `{this}` is used in a static context
b. Support `{this}` in async methods (search for the `<>4__this` field, add it if it doesn't exist)
c. Support `{this}` in regular methods (use ldarg_0)