### PR TITLE
Simplify async method handling and fix some bugs

### DIFF
--- a/AssemblyWithInterceptor/ClassWithAsyncMethod.cs
+++ b/AssemblyWithInterceptor/ClassWithAsyncMethod.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using MethodTimer;
 #pragma warning disable 414
+#pragma warning disable S112
 
 public class ClassWithAsyncMethod
 {
@@ -39,5 +41,28 @@ public class ClassWithAsyncMethod
         }
 
         isRunning = false;
+    }
+
+    [Time]
+    public async Task MethodWithExceptionAsync()
+    {
+        await Task.Delay(1000);
+        throw new Exception();
+    }
+
+    public async Task MethodWithExceptionAsync_Expected()
+    {
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            await Task.Delay(1000);
+            throw new Exception();
+        }
+        finally
+        {
+            sw.Stop();
+            Trace.WriteLine($"Program.AsyncDelayWithTimer {sw.Elapsed}ms");
+        }
     }
 }

--- a/AssemblyWithInterceptor/MethodTimeLogger.cs
+++ b/AssemblyWithInterceptor/MethodTimeLogger.cs
@@ -6,11 +6,17 @@ public static class MethodTimeLogger
 {
 
     public static List<MethodBase> MethodBase = new List<MethodBase>();
+    public static List<string> Messages = new List<string>();
 
-    public static void Log(MethodBase methodBase, long milliseconds)
+    public static void Log(MethodBase methodBase, long milliseconds, string message)
     {
         Console.WriteLine(methodBase.Name + " " + milliseconds);
         MethodBase.Add(methodBase);
+
+        if (message != null)
+        {
+            Messages.Add(message);
+        }
     }
 
 }

--- a/MethodTimer.Fody/AsyncMethodProcessor.cs
+++ b/MethodTimer.Fody/AsyncMethodProcessor.cs
@@ -12,8 +12,9 @@ public class AsyncMethodProcessor
     public MethodDefinition Method;
     MethodBody body;
     FieldDefinition stopwatchField;
+    FieldDefinition stateField;
     TypeDefinition stateMachineType;
-    List<Instruction> returnPoints;
+    MethodDefinition stopStopwatchMethod;
     ParameterFormattingProcessor parameterFormattingProcessor = new ParameterFormattingProcessor();
 
     public void Process()
@@ -39,9 +40,6 @@ public class AsyncMethodProcessor
         body = moveNextMethod.Body;
 
         body.SimplifyMacros();
-
-        returnPoints = GetAsyncReturns(body.Instructions)
-            .ToList();
 
         // First, fall back to old mechanism
         int index;
@@ -70,14 +68,43 @@ public class AsyncMethodProcessor
             index = body.Instructions.IndexOf(firstStateUsage) - 1;
         }
 
-        InjectStopwatch(index, body.Instructions[index]);
+        stateField = (from x in stateMachineType.Fields
+                      where x.Name.EndsWith("__state")
+                      select x).First();
 
-        HandleReturns();
+        InjectStopwatchStart(index, body.Instructions[index]);
+        InjectStopwatchStopMethod();
+        InjectStopwatchStopCalls();
+
         body.InitLocals = true;
         body.OptimizeMacros();
     }
 
-    void InjectStopwatch(int index, Instruction nextInstruction)
+    Instruction FixReturns()
+    {
+        var instructions = body.Instructions;
+
+        // We inject both a nop and return. This allows us to inject between the nop
+        // and the return
+        var nop = Instruction.Create(OpCodes.Nop);
+        var lastRet = Instruction.Create(OpCodes.Ret);
+
+        foreach (var instruction in instructions)
+        {
+            if (instruction.OpCode == OpCodes.Ret)
+            {
+                instruction.OpCode = OpCodes.Leave;
+                instruction.Operand = nop;
+            }
+        }
+
+        instructions.Add(nop);
+        instructions.Add(lastRet);
+
+        return lastRet;
+    }
+
+    void InjectStopwatchStart(int index, Instruction nextInstruction)
     {
         var boolVariable = new VariableDefinition(ModuleWeaver.BooleanType.Resolve());
         body.Variables.Add(boolVariable);
@@ -105,111 +132,111 @@ public class AsyncMethodProcessor
         });
     }
 
-    void HandleReturns()
+    void InjectStopwatchStopMethod()
     {
-        foreach (var returnPoint in returnPoints)
+        if (stopStopwatchMethod != null)
         {
-            FixReturn(returnPoint);
+            return;
         }
+
+        var method = new MethodDefinition("StopMethodTimerStopwatch", MethodAttributes.Private, ModuleWeaver.VoidType);
+
+        var methodBody = method.Body;
+        methodBody.SimplifyMacros();
+
+        var stopwatchInstructions = GetWriteTimeInstruction(method).ToList();
+
+        foreach (var instruction in stopwatchInstructions)
+        {
+            methodBody.Instructions.Add(instruction);
+        }
+
+        methodBody.Instructions.Add(Instruction.Create(OpCodes.Ret));
+
+        methodBody.InitLocals = true;
+        methodBody.OptimizeMacros();
+
+        stateMachineType.Methods.Add(method);
+
+        stopStopwatchMethod = method;
     }
 
-    static IEnumerable<Instruction> GetAsyncReturns(Collection<Instruction> instructions)
+    void InjectStopwatchStopCalls()
     {
-        // There are 3 possible return points:
-        //
-        // 1) async code:
-        //      awaiter.GetResult();
-        //      awaiter = new TaskAwaiter();
-        //
-        // 2) exception handling
-        //      L_00d5: ldloc.1
-        //      L_00d6: call instance void [mscorlib]System.Runtime.CompilerServices.AsyncTaskMethodBuilder::SetException(class [mscorlib]System.Exception)
-        //
-        // 3) all other returns
-        //
-        // We can do this smart by searching for all leave and leave_S op codes and check if they point to the last
-        // instruction of the method. This equals a "return" call.
+        // There are 2 locations where the stopwatch logic should be injected:
+        // 1: just before the ::SetException
+        // 2: end of the method (which is not executed after calling ::SetException) or just after SetResult
 
-        var returnStatements = new List<Instruction>();
-
-        var possibleReturnStatements = new List<Instruction>();
-
-        // Look for the last leave statement (that is the line all "return" statements go to)
-        for (var i = instructions.Count - 1; i >= 0; i--)
+        var stopwatchInstructions = new List<Instruction>(new[]
         {
-            var instruction = instructions[i];
-            if (instruction.IsLeaveInstruction())
+            Instruction.Create(OpCodes.Ldarg_0),
+            Instruction.Create(OpCodes.Call, stopStopwatchMethod)
+        });
+
+        var returnInstruction = FixReturns();
+        var endInstruction = returnInstruction;
+
+        // 1: SetException: We will search for the last known catch block, and implement a finally there with the stopwatch code
+        var exceptionHandler = (from handler in body.ExceptionHandlers
+                                orderby handler.HandlerEnd.Offset descending
+                                select handler).FirstOrDefault();
+        if (exceptionHandler != null)
+        {
+            var catchStartIndex = body.Instructions.IndexOf(exceptionHandler.HandlerStart);
+            var catchEndIndex = body.Instructions.IndexOf(exceptionHandler.HandlerEnd);
+
+            for (var i = catchEndIndex; i >= catchStartIndex; i--)
             {
-                possibleReturnStatements.Add(instructions[i + 1]);
+                if (body.Instructions[i].Operand is MethodReference methodReference &&
+                    methodReference.Name == "SetException")
+                {
+                    // Insert before
+                    for (var j = 0; j < stopwatchInstructions.Count; j++)
+                    {
+                        body.Instructions.Insert(i + j, stopwatchInstructions[j]);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        // 2: end of the method (either SetResult or end of the method)
+        for (var i = body.Instructions.Count - 1; i >= 0; i--)
+        {
+            if (body.Instructions[i].Operand is MethodReference methodReference &&
+                methodReference.Name == "SetResult")
+            {
+                // Next index, we want this to appear *after* the SetResult call
+                endInstruction = body.Instructions[i + 1];
                 break;
             }
         }
 
-        for (var i = 0; i < instructions.Count; i++)
+        var startIndex = body.Instructions.IndexOf(endInstruction);
+
+        for (var i = 0; i < stopwatchInstructions.Count; i++)
         {
-            var instruction = instructions[i];
-            if (instruction.IsLeaveInstruction())
-            {
-                if (possibleReturnStatements.Any(x => ReferenceEquals(instruction.Operand, x)))
-                {
-                    // This is a return statement, this covers scenarios 1 and 3
-                    returnStatements.Add(instruction);
-                }
-                else
-                {
-                    // Check if we set an exception in this block, this covers scenario 2
-                    for (var j = i - 3; j < i; j++)
-                    {
-                        var previousInstruction = instructions[j];
-                        if (previousInstruction.OpCode == OpCodes.Call)
-                        {
-                            if (previousInstruction.Operand is MethodReference methodReference)
-                            {
-                                if (methodReference.Name.Equals("SetException"))
-                                {
-                                    returnStatements.Add(instruction);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return returnStatements;
-    }
-
-    void FixReturn(Instruction returnPoint)
-    {
-        var opCode = returnPoint.OpCode;
-        var operand = returnPoint.Operand as Instruction;
-
-        returnPoint.OpCode = OpCodes.Nop;
-        returnPoint.Operand = null;
-
-        var instructions = body.Instructions;
-        var indexOf = instructions.IndexOf(returnPoint);
-        foreach (var instruction in GetWriteTimeInstruction(Method))
-        {
-            indexOf++;
-            instructions.Insert(indexOf, instruction);
-        }
-
-        indexOf++;
-
-        if (opCode == OpCodes.Leave || opCode == OpCodes.Leave_S)
-        {
-            instructions.Insert(indexOf, Instruction.Create(opCode, operand));
-        }
-        else
-        {
-            instructions.Insert(indexOf, Instruction.Create(opCode));
+            body.Instructions.Insert(startIndex++, stopwatchInstructions[i]);
         }
     }
 
-    IEnumerable<Instruction> GetWriteTimeInstruction(MethodDefinition methodDefinition)
+    IEnumerable<Instruction> GetWriteTimeInstruction(MethodDefinition method)
     {
+        var boolVariable = new VariableDefinition(ModuleWeaver.BooleanType.Resolve());
+        method.Body.Variables.Add(boolVariable);
+
+        var nopInstruction = Instruction.Create(OpCodes.Nop);
+
+        // Check if state machine is completed (state == -2)
+        yield return Instruction.Create(OpCodes.Ldarg_0);
+        yield return Instruction.Create(OpCodes.Ldfld, stateField);
+        yield return Instruction.Create(OpCodes.Ldc_I4, -2);
+        yield return Instruction.Create(OpCodes.Ceq);
+        yield return Instruction.Create(OpCodes.Stloc, boolVariable);
+        yield return Instruction.Create(OpCodes.Ldloc, boolVariable);
+        yield return Instruction.Create(OpCodes.Brfalse_S, nopInstruction);
+
         yield return Instruction.Create(OpCodes.Ldarg_0);
         yield return Instruction.Create(OpCodes.Ldfld, stopwatchField);
         yield return Instruction.Create(OpCodes.Call, ModuleWeaver.StopMethod);
@@ -224,7 +251,7 @@ public class AsyncMethodProcessor
         {
             if (logMethodUsingLong is null && logMethodUsingTimeSpan is null)
             {
-                yield return Instruction.Create(OpCodes.Ldstr, methodDefinition.MethodName());
+                yield return Instruction.Create(OpCodes.Ldstr, Method.MethodName());
                 yield return Instruction.Create(OpCodes.Ldarg_0);
                 yield return Instruction.Create(OpCodes.Ldfld, stopwatchField);
                 yield return Instruction.Create(OpCodes.Call, ModuleWeaver.ElapsedMilliseconds);
@@ -232,70 +259,74 @@ public class AsyncMethodProcessor
                 yield return Instruction.Create(OpCodes.Ldstr, "ms");
                 yield return Instruction.Create(OpCodes.Call, ModuleWeaver.ConcatMethod);
                 yield return Instruction.Create(OpCodes.Call, ModuleWeaver.TraceWriteLineMethod);
-                yield break;
+            }
+            else
+            {
+                yield return Instruction.Create(OpCodes.Ldtoken, Method);
+                yield return Instruction.Create(OpCodes.Ldtoken, Method.DeclaringType);
+                yield return Instruction.Create(OpCodes.Call, ModuleWeaver.GetMethodFromHandle);
+                yield return Instruction.Create(OpCodes.Ldarg_0);
+                yield return Instruction.Create(OpCodes.Ldfld, stopwatchField);
+
+                if (logMethodUsingTimeSpan is null)
+                {
+                    yield return Instruction.Create(OpCodes.Call, ModuleWeaver.ElapsedMilliseconds);
+                    yield return Instruction.Create(OpCodes.Call, logMethodUsingLong);
+                }
+                else
+                {
+                    yield return Instruction.Create(OpCodes.Call, ModuleWeaver.Elapsed);
+                    yield return Instruction.Create(OpCodes.Call, logMethodUsingTimeSpan);
+                }
+            }
+        }
+        else
+        {
+            // Important notes:
+            // 1. Because async works with state machines, use the state machine & fields instead of method & variables.
+            // 2. The ldarg_0 calls are required to load the state machine class and is required before every field call.
+
+            var formattedFieldDefinition = stateMachineType.Fields.FirstOrDefault(x => x.Name.Equals("methodTimerMessage"));
+            if (formattedFieldDefinition is null)
+            {
+                formattedFieldDefinition = new FieldDefinition("methodTimerMessage", FieldAttributes.Private | FieldAttributes.CompilerControlled, ModuleWeaver.TypeSystem.StringReference);
+                stateMachineType.Fields.Add(formattedFieldDefinition);
             }
 
-            yield return Instruction.Create(OpCodes.Ldtoken, methodDefinition);
-            yield return Instruction.Create(OpCodes.Ldtoken, methodDefinition.DeclaringType);
+            foreach (var instruction in ProcessTimeAttribute(Method, formattedFieldDefinition))
+            {
+                yield return instruction;
+            }
+
+            // Handle call to log method
+            yield return Instruction.Create(OpCodes.Ldtoken, Method);
+            yield return Instruction.Create(OpCodes.Ldtoken, Method.DeclaringType);
             yield return Instruction.Create(OpCodes.Call, ModuleWeaver.GetMethodFromHandle);
             yield return Instruction.Create(OpCodes.Ldarg_0);
             yield return Instruction.Create(OpCodes.Ldfld, stopwatchField);
 
-            if (logMethodUsingTimeSpan is null)
+            if (logWithMessageMethodUsingTimeSpan is null)
             {
                 yield return Instruction.Create(OpCodes.Call, ModuleWeaver.ElapsedMilliseconds);
-                yield return Instruction.Create(OpCodes.Call, logMethodUsingLong);
-
-                yield break;
+                yield return Instruction.Create(OpCodes.Ldarg_0);
+                yield return Instruction.Create(OpCodes.Ldfld, formattedFieldDefinition);
+                yield return Instruction.Create(OpCodes.Call, logWithMessageMethodUsingLong);
             }
-
-            yield return Instruction.Create(OpCodes.Call, ModuleWeaver.Elapsed);
-            yield return Instruction.Create(OpCodes.Call, logMethodUsingTimeSpan);
-            yield break;
+            else
+            {
+                yield return Instruction.Create(OpCodes.Call, ModuleWeaver.Elapsed);
+                yield return Instruction.Create(OpCodes.Ldarg_0);
+                yield return Instruction.Create(OpCodes.Ldfld, formattedFieldDefinition);
+                yield return Instruction.Create(OpCodes.Call, logWithMessageMethodUsingTimeSpan);
+            }
         }
 
-
-        // Important notes:
-        // 1. Because async works with state machines, use the state machine & fields instead of method & variables.
-        // 2. The ldarg_0 calls are required to load the state machine class and is required before every field call.
-
-        var formattedFieldDefinition = stateMachineType.Fields.FirstOrDefault(x => x.Name.Equals("methodTimerMessage"));
-        if (formattedFieldDefinition is null)
-        {
-            formattedFieldDefinition = new FieldDefinition("methodTimerMessage", FieldAttributes.Private | FieldAttributes.CompilerControlled, ModuleWeaver.TypeSystem.StringReference);
-            stateMachineType.Fields.Add(formattedFieldDefinition);
-        }
-
-        foreach (var instruction in ProcessTimeAttribute(methodDefinition, formattedFieldDefinition))
-        {
-            yield return instruction;
-        }
-
-        // Handle call to log method
-        yield return Instruction.Create(OpCodes.Ldtoken, methodDefinition);
-        yield return Instruction.Create(OpCodes.Ldtoken, methodDefinition.DeclaringType);
-        yield return Instruction.Create(OpCodes.Call, ModuleWeaver.GetMethodFromHandle);
-        yield return Instruction.Create(OpCodes.Ldarg_0);
-        yield return Instruction.Create(OpCodes.Ldfld, stopwatchField);
-
-        if (logWithMessageMethodUsingTimeSpan is null)
-        {
-            yield return Instruction.Create(OpCodes.Call, ModuleWeaver.ElapsedMilliseconds);
-            yield return Instruction.Create(OpCodes.Ldarg_0);
-            yield return Instruction.Create(OpCodes.Ldfld, formattedFieldDefinition);
-            yield return Instruction.Create(OpCodes.Call, logWithMessageMethodUsingLong);
-            yield break;
-        }
-
-        yield return Instruction.Create(OpCodes.Call, ModuleWeaver.Elapsed);
-        yield return Instruction.Create(OpCodes.Ldarg_0);
-        yield return Instruction.Create(OpCodes.Ldfld, formattedFieldDefinition);
-        yield return Instruction.Create(OpCodes.Call, logWithMessageMethodUsingTimeSpan);
+        yield return nopInstruction;
     }
 
     IEnumerable<Instruction> ProcessTimeAttribute(MethodDefinition methodDefinition, FieldDefinition formattedFieldDefinition)
     {
-// Load everything for a string format
+        // Load everything for a string format
         var timeAttribute = methodDefinition.GetTimeAttribute();
         if (timeAttribute != null)
         {

--- a/MethodTimer.Fody/MethodProcessor.cs
+++ b/MethodTimer.Fody/MethodProcessor.cs
@@ -116,6 +116,7 @@ public class MethodProcessor
         instructions.Add(Instruction.Create(OpCodes.Ret));
         return lastLd;
     }
+
     void InjectIlForFinally(Instruction beforeThis)
     {
         foreach (var instruction in ModuleWeaver.GetWriteTimeInstruction(stopwatchVar, Method))
@@ -125,5 +126,4 @@ public class MethodProcessor
 
         body.InsertBefore(beforeThis, Instruction.Create(OpCodes.Endfinally));
     }
-
 }

--- a/MethodTimer.Fody/ReferenceFinder.cs
+++ b/MethodTimer.Fody/ReferenceFinder.cs
@@ -9,6 +9,7 @@ public partial class ModuleWeaver
     public TypeReference StopwatchType;
     public MethodReference StringFormatWithArray;
     public MethodReference ConcatMethod;
+    public MethodReference IsRunning;
     public MethodReference Elapsed;
     public MethodReference ElapsedMilliseconds;
     public MethodReference GetMethodFromHandle;
@@ -18,6 +19,7 @@ public partial class ModuleWeaver
     public MethodReference UtcNowMethod;
     public TypeReference DateTimeType;
     public TypeReference BooleanType;
+    public TypeReference VoidType;
 
     public void FindReferences()
     {
@@ -50,6 +52,9 @@ public partial class ModuleWeaver
         var booleanType = FindType("System.Boolean");
         BooleanType = ModuleDefinition.ImportReference(booleanType);
 
+        var voidType = FindType("System.Void");
+        VoidType = ModuleDefinition.ImportReference(voidType);
+
         if (TryFindType("System.Diagnostics.Stopwatch", out var stopwatchType))
         {
             StopwatchType = ModuleDefinition.ImportReference(stopwatchType);
@@ -57,6 +62,7 @@ public partial class ModuleWeaver
             StopMethod = ModuleDefinition.ImportReference(stopwatchType.Method("Stop"));
             Elapsed = ModuleDefinition.ImportReference(stopwatchType.Method("get_Elapsed"));
             ElapsedMilliseconds = ModuleDefinition.ImportReference(stopwatchType.Method("get_ElapsedMilliseconds"));
+            IsRunning = ModuleDefinition.ImportReference(stopwatchType.Method("get_IsRunning"));
         }
         else
         {

--- a/Tests/TraceRunner.cs
+++ b/Tests/TraceRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 
 public class TraceRunner
 {
@@ -21,4 +22,20 @@ public class TraceRunner
         return myTraceListener.Messages;
     }
 
+    public static async Task<List<string>> CaptureAsync(Func<Task> action)
+    {
+        var myTraceListener = new MyTraceListener();
+        try
+        {
+            Trace.Listeners.Add(myTraceListener);
+            await action();
+            Thread.Sleep(100);
+        }
+        finally
+        {
+            Trace.Listeners.Remove(myTraceListener);
+        }
+
+        return myTraceListener.Messages;
+    }
 }


### PR DESCRIPTION
#### Description

Fixes #124 

#### The solution

The reason it was not working correctly is because of the throwing of the exception that caused no other exit paths available in the example method.

I've much simplified the way MethodTimer deals with async methods by changing the following:

1. Add member method that only logs when the state machine is complete (state value == -2)
2. Call this method after every MoveNext call at the end of the method *or* before SetException (then the method execution stops as well)

Here is the output of a test console app:

![image](https://user-images.githubusercontent.com/1246444/67896184-25211980-fb5c-11e9-84b4-6664accd5d6b.png)

The bottom one is from the repro provided by @adrianignat13 

Here is the updated generated code after weaving for a state machine:

**StopMethodTimerStopwatch()**

```
private void StopMethodTimerStopwatch()
{
    if (this.<>__state != -2)
        return;
    this.methodTimerStopwatch.Stop();
    this.methodTimerMessage = (string) null;
    MethodTimeLogger.Log(MethodBase.GetMethodFromHandle(__methodref (Program.AsyncDelay), __typeref (Program)), this.methodTimerStopwatch.ElapsedMilliseconds, this.    
}
```

**MoveNext()**

As you can see, there are 2 places where `StopMethodTimerStopwatch` is being called, just before `SetException` and at the end of the method)

```
void IAsyncStateMachine.MoveNext()
{
    if (this.methodTimerStopwatch == null)
        this.methodTimerStopwatch = Stopwatch.StartNew();
    int num1 = this.<>1__state;
    try
    {
      TaskAwaiter awaiter;
      int num2;
      if (num1 != 0)
      {
        awaiter = Task.Delay(1000).GetAwaiter();
        if (!awaiter.IsCompleted)
        {
            this.<>1__state = num2 = 0;
            this.<>u__1 = awaiter;
            Program.<AsyncDelay>d__7 stateMachine = this;
            this.<>t__builder.AwaitUnsafeOnCompleted<TaskAwaiter, Program.<AsyncDelay>d__7>(ref awaiter, ref stateMachine);
            goto label_9;
        }
      }
      else
      {
        awaiter = this.<>u__1;
        this.<>u__1 = new TaskAwaiter();
        this.<>1__state = num2 = -1;
      }
      awaiter.GetResult();
      throw new Exception();
    }
    catch (Exception ex)
    {
        this.<>1__state = -2;
        ref AsyncTaskMethodBuilder local = ref this.<>t__builder;
        Exception exception = ex;
        this.StopMethodTimerStopwatch();
        local.SetException(exception);
    }
    label_9:
    this.StopMethodTimerStopwatch();
}
```