### PR TITLE
Prevent duplicate logs by checking whether the stopwatch is actually running

### DIFF
--- a/MethodTimer.Fody/AsyncMethodProcessor.cs
+++ b/MethodTimer.Fody/AsyncMethodProcessor.cs
@@ -192,7 +192,6 @@ public class AsyncMethodProcessor
                     {
                         body.Instructions.Insert(i + j, stopwatchInstructions[j]);
                     }
-
                     break;
                 }
             }
@@ -220,13 +219,23 @@ public class AsyncMethodProcessor
 
     IEnumerable<Instruction> GetWriteTimeInstruction(MethodDefinition method)
     {
+        var stopwatchRunningCheck = Instruction.Create(OpCodes.Ldarg_0);
         var startOfRealMethod = Instruction.Create(OpCodes.Ldarg_0);
 
         // Check if state machine is completed (state == -2)
         yield return Instruction.Create(OpCodes.Ldarg_0);
         yield return Instruction.Create(OpCodes.Ldfld, stateField);
         yield return Instruction.Create(OpCodes.Ldc_I4, -2);
-        yield return Instruction.Create(OpCodes.Beq_S, startOfRealMethod);
+        yield return Instruction.Create(OpCodes.Beq_S, stopwatchRunningCheck);
+        yield return Instruction.Create(OpCodes.Ret);
+
+        // Check if stopwatch is actually running
+        yield return stopwatchRunningCheck;
+        yield return Instruction.Create(OpCodes.Ldfld, stopwatchFieldReference);
+        yield return Instruction.Create(OpCodes.Callvirt, ModuleWeaver.IsRunning);
+        yield return Instruction.Create(OpCodes.Ldc_I4_0);
+        yield return Instruction.Create(OpCodes.Ceq);
+        yield return Instruction.Create(OpCodes.Brfalse_S, startOfRealMethod);
         yield return Instruction.Create(OpCodes.Ret);
 
         yield return startOfRealMethod; // Ldarg_0


### PR DESCRIPTION
Fixes #124 . Note that this only occured to async methods that throw an exception. 

This PR adds an additional check in the `StopStopwatch` method:

![image](https://user-images.githubusercontent.com/1246444/68168523-4d988180-ff69-11e9-9abc-0b62433a7cb0.png)
